### PR TITLE
검색 기능 활성화 및 주석처리, 불필요 메서드 제거

### DIFF
--- a/src/main/java/com/ever/autoever_1st/notice/constant/SearchType.java
+++ b/src/main/java/com/ever/autoever_1st/notice/constant/SearchType.java
@@ -1,7 +1,7 @@
 package com.ever.autoever_1st.notice.constant;
 
 public enum SearchType {
+    ALL_CATEGORY,   // 전체
     TITLE,      // 제목
-    CONTENTS,   // 내용
     WRITER;     // 작성자
 }

--- a/src/main/java/com/ever/autoever_1st/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/ever/autoever_1st/notice/repository/NoticeRepository.java
@@ -1,7 +1,5 @@
 package com.ever.autoever_1st.notice.repository;
 
-import com.ever.autoever_1st.notice.constant.TargetRange;
-import com.ever.autoever_1st.notice.constant.Type;
 import com.ever.autoever_1st.notice.entities.Notice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,24 +11,16 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
-    // TargetRange와 Type 조건으로 페이징 검색
-    Page<Notice> findByTargetRangeAndType(TargetRange targetRange, Type type, Pageable pageable);
-
     // title 에 text가 포함된 공지
     Page<Notice> findByTitleContainingIgnoreCaseOrderByIsPinnedDescIdDesc(
-            String text, Pageable pageable);
-    // contents 에 text가 포함된 공지
-    Page<Notice> findByContentsContainingIgnoreCaseOrderByIsPinnedDescIdDesc(
             String text, Pageable pageable);
     // writer 에 text가 포함된 공지
     Page<Notice> findByWriterContainingIgnoreCaseOrderByIsPinnedDescIdDesc(
             String text, Pageable pageable);
-    /* ▶︎ “제목 | 내용 | 작성자 세 필드 전부 한 번에” 라는 요구가 있으면
-          JPQL 하나로 뽑는 방법도 가능. 필요하면 주석 풀어서 써! */
+    // 모든 경우에 text가 포함된 공지
     @Query("""
                    SELECT n FROM Notice n
                    WHERE LOWER(n.title)    LIKE LOWER(CONCAT('%', :text, '%'))
-                      OR LOWER(n.contents) LIKE LOWER(CONCAT('%', :text, '%'))
                       OR LOWER(n.writer)   LIKE LOWER(CONCAT('%', :text, '%'))
                    ORDER BY n.isPinned DESC, n.id DESC
                """)
@@ -38,8 +28,4 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     // startDate와 endDate 사이에 있는 TargetDate(not null, 상단 고정 내림차순, 작성일 내림차순)
     List<Notice> findByTargetDateIsNotNullAndTargetDateBetweenOrderByIsPinnedDescRegistedAtDesc(
             LocalDate startDate, LocalDate endDate);
-
-    Page<Notice> findByTargetRange(TargetRange targetRange, Pageable pageable);
-
-    Page<Notice> findByType(Type type, Pageable pageable);
 }

--- a/src/main/java/com/ever/autoever_1st/notice/service/impl/NoticeServiceImpl.java
+++ b/src/main/java/com/ever/autoever_1st/notice/service/impl/NoticeServiceImpl.java
@@ -1,8 +1,6 @@
 package com.ever.autoever_1st.notice.service.impl;
 
 import com.ever.autoever_1st.notice.constant.SearchType;
-import com.ever.autoever_1st.notice.constant.TargetRange;
-import com.ever.autoever_1st.notice.constant.Type;
 import com.ever.autoever_1st.notice.dto.req.NoticeWriteDto;
 import com.ever.autoever_1st.notice.dto.res.NoticeDto;
 import com.ever.autoever_1st.notice.repository.NoticeRepository;
@@ -74,10 +72,9 @@ public class NoticeServiceImpl implements NoticeService {
                 .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다. : " + memberEmail));
         // ── SearchType 에 따라 다른 JPA 쿼리 호출
         Page<Notice> page = switch (searchType) {
+            case ALL_CATEGORY -> noticeRepository.searchEverywhere(text,pageable);
             case TITLE    -> noticeRepository
                     .findByTitleContainingIgnoreCaseOrderByIsPinnedDescIdDesc(text, pageable);
-            case CONTENTS -> noticeRepository
-                    .findByContentsContainingIgnoreCaseOrderByIsPinnedDescIdDesc(text, pageable);
             case WRITER   -> noticeRepository
                     .findByWriterContainingIgnoreCaseOrderByIsPinnedDescIdDesc(text, pageable);
         };


### PR DESCRIPTION
검색 기능(SearchType)
- 내용으로 검색 ( CONTENT ) enum 제거
- 전체 검색 (ALL_CATEGORY) enum 추가

불필요 메서드 제거 (NoticeRepository)
- 내용으로 검색
Page<Notice> findByContentsContainingIgnoreCaseOrderByIsPinnedDescIdDesc(String text, Pageable pageable);
- 안 사용하는데 남아있던 공지유형, 반별 검색 제거
Page<Notice> findByTargetRange(TargetRange targetRange, Pageable pageable);
Page<Notice> findByType(Type type, Pageable pageable);
- 이에 따라 주석처리된 관련 import 문 제거
